### PR TITLE
abs for convergence when one state is fixed

### DIFF
--- a/lib/hmmlearn/base.py
+++ b/lib/hmmlearn/base.py
@@ -114,7 +114,7 @@ class ConvergenceMonitor:
         # XXX we might want to check that ``logprob`` is non-decreasing.
         return (self.iter == self.n_iter or
                 (len(self.history) >= 2 and
-                 self.history[-1] - self.history[-2] < self.tol))
+                 abs(self.history[-1] - self.history[-2]) < self.tol))
 
 
 class _BaseHMM(BaseEstimator):


### PR DESCRIPTION
The state with the lowest mean could be constantly fixed (mean and covariance). In this case the difference of the logProb for the previous and current state could be negative because of the implicit constraint. It shouldn't be a stop-flag for the finding a maximum.